### PR TITLE
Add description to support RSpec's attribute of subject

### DIFF
--- a/lib/json_expressions/rspec/matchers/match_json_expression.rb
+++ b/lib/json_expressions/rspec/matchers/match_json_expression.rb
@@ -24,6 +24,10 @@ module JsonExpressions
         def failure_message_for_should_not
           "expected #{@target.inspect} not to match JSON expression #{@expected.inspect}"
         end
+
+        def description
+          "should equal JSON expression #{@expected.inspect}"
+        end
       end
 
       def match_json_expression(expected)


### PR DESCRIPTION
This is a patch to support RSpec's attribute of subject function.

When I use the function, the matching works fine, but I get the following message.

> should When you call a matcher in an example without a String, like this:
> 
> specify { object.should matcher }
> 
> or this:
> 
> it { should matcher }
> 
> RSpec expects the matcher to have a #description method. You should either
> add a String to the example this matcher is being used in, or give it a
> description method. Then you won't have to suffer this lengthy warning again.

The explanation of "attribute of subject" is found in the below url.
https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/subject/attribute-of-subject
