### PR TITLE
Require "rspec/core" not "rspec".

### DIFF
--- a/lib/json_expressions/rspec.rb
+++ b/lib/json_expressions/rspec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require 'rspec/core'
 require 'json_expressions'
 require 'json_expressions/rspec/matchers'
 

--- a/lib/json_expressions/rspec/matchers/match_json_expression.rb
+++ b/lib/json_expressions/rspec/matchers/match_json_expression.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'rspec/core'
 
 module JsonExpressions
   module RSpec


### PR DESCRIPTION
There are cases where rspec-core is present but rspec is not.

The rspec-rails gem as of 2.12.0 does not depend on "rspec", but instead
lists "rspec-core" and other rspec gems as dependencies.

Without this change, json_expressions crashes newer Rails + Rspec projects
with a LoadError.
