### PR TITLE
Support using match_json_expression as an argument matcher.

### DIFF
--- a/lib/json_expressions/rspec/matchers/match_json_expression.rb
+++ b/lib/json_expressions/rspec/matchers/match_json_expression.rb
@@ -17,6 +17,7 @@ module JsonExpressions
           @target = (String === target) ? JSON.parse(target) : target
           @expected =~ @target
         end
+        alias_method :===, :matches?
 
         def failure_message_for_should
           "expected #{@target.inspect} to match JSON expression #{@expected.inspect}\n" + @expected.last_error


### PR DESCRIPTION
The argument matchers, and the expect change matcher, rely on `===` being defined for a matcher. This allows the `match_json_expression` to be used in these places.
