### PR TITLE
Add support for rspec 3+

### DIFF
--- a/lib/json_expressions/rspec/matchers/match_json_expression.rb
+++ b/lib/json_expressions/rspec/matchers/match_json_expression.rb
@@ -22,10 +22,12 @@ module JsonExpressions
         def failure_message_for_should
           "expected #{@target.inspect} to match JSON expression #{@expected.inspect}\n" + @expected.last_error
         end
+        alias_method :failure_message, :failure_message_for_should
 
         def failure_message_for_should_not
           "expected #{@target.inspect} not to match JSON expression #{@expected.inspect}"
         end
+        alias_method :failure_message_when_negated, :failure_message_for_should_not
 
         def description
           "should equal JSON expression #{@expected.inspect}"


### PR DESCRIPTION
Alias new rspec matcher protocol names (rspec 3+) to the old (rspec 2). From https://www.relishapp.com/rspec/rspec-expectations/docs/changelog:

Update matcher protocol and custom matcher DSL to better align with the newer expect syntax. If you want your matchers to maintain compatibility with multiple versions of RSpec, you can alias the new names to the old. (Myron Marston)
- failure_message_for_should => failure_message
- failure_message_for_should_not => failure_message_when_negated
- match_for_should => match
- match_for_should_not => match_when_negated

---

Running `rspec v3.0.0.beta2` without this patch results in the following:

```
   Failure/Error: expect(last_response.body).to match_json_expression(expected_json_pattern)
   --------------------------------------------------------------------------
   JsonExpressions::RSpec::Matchers::MatchJsonExpression implements a legacy RSpec matcher
   protocol. For the current protocol you should expose the failure messages
   via the `failure_message` and `failure_message_when_negated` methods.
   (Used from <path>/spec/support/shared_api_endpoint_spec.rb:101:in `block (3 levels) in <top (required)>')
   --------------------------------------------------------------------------
```
