### PR TITLE
Print more detailed error message when matching arrays

### DIFF
--- a/lib/json_expressions/matcher.rb
+++ b/lib/json_expressions/matcher.rb
@@ -124,11 +124,11 @@ module JsonExpressions
         other = other.clone
 
         matcher.all? do |v1|
-          if i = other.find_index { |v2| match_json(nil, v1, v2) }
+          if i = other.find_index { |v2| match_json(make_path(path, '*'), v1, v2) }
             other.delete_at i
             true
           else
-            set_last_error path, "%path% does not contain an element matching #{v1.inspect}"
+            set_last_error path, "%path% does not contain a matching element for #{v1.inspect} - #{last_error}"
             false
           end
         end

--- a/test/json_expressions/test_matcher.rb
+++ b/test/json_expressions/test_matcher.rb
@@ -305,7 +305,14 @@ module JsonExpressions
     def test_error_array_unordered_no_match
       m = Matcher.new([1,2,3,4,5].unordered!)
       m =~ [1,2,3,4,6]
-      assert_equal '(JSON ROOT) does not contain an element matching 5', m.last_error
+      assert_equal '(JSON ROOT) does not contain a matching element for 5 - At (JSON ROOT).*: expected 5 to match 6', m.last_error
+    end
+
+    def test_array_with_hash_inside
+      m = Matcher.new([{foo: 'bar'}])
+      m =~ [{}]
+
+      assert_equal "(JSON ROOT) does not contain a matching element for #{{foo: 'bar'}} - (JSON ROOT).* does not contain the key foo", m.last_error
     end
 
     def test_error_not_a_hash


### PR DESCRIPTION
I have found myself often matching arrays of objects inside another object. It's really hard to find a source of error when it just prints "does not contain a matching element {some_massive_object_here}".
